### PR TITLE
center the footer

### DIFF
--- a/_common/styles/general.scss
+++ b/_common/styles/general.scss
@@ -172,6 +172,7 @@ div.footer {
     text-decoration: none;
     white-space:nowrap; /* prevent a single link (logo+words) from wrapping internally */
     margin-right: 10px;
+    line-height: 44px; 
   }
 }
 

--- a/_common/styles/general.scss
+++ b/_common/styles/general.scss
@@ -159,8 +159,7 @@ td:nth-child(1){
 div.footer {
   background-color: $gray-lighter;
   font-size: 14px;
-  padding-top: 36px;
-  padding-bottom: 10px;
+  padding: 36px 0;
 
   img {
     height: auto;

--- a/htmlpartials/footer.js
+++ b/htmlpartials/footer.js
@@ -1,16 +1,17 @@
 const htmlblock = `
-    <div class="container-fluid footer">
+    <div class="footer">
+    <div class="container">
     <div class="row">
-        <p class="col-md-2">
+        <p class="col-md-3">
             <a target="_blank" href="mailto:info@planscore.org"><img src="https://planscore.org/images/email-logo.svg"> info@planscore.org</a>
         </p>
-        <p class="col-md-2">
+        <p class="col-md-3">
             <a target="_blank" href="https://twitter.com/PlanScore"><img src="https://planscore.org/images/twitter-logo.svg"> @PlanScore</a>
         </p>
-        <p class="col-md-2">
+        <p class="col-md-3">
             <a target="_blank" href="https://github.com/PlanScore/PlanScore"><img src="https://planscore.org/images/github-logo.svg"> Github</a>
         </p>
-        <form class="col-md-2" action="https://www.paypal.com/donate" method="post" target="_top">
+        <form class="col-md-3" action="https://www.paypal.com/donate" method="post" target="_top">
             <input type="hidden" name="hosted_button_id" value="C9G45F294EKEG" />
             <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
             <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
@@ -20,6 +21,7 @@ const htmlblock = `
         <span class="col-md-12">
             PlanScore is a 501(c)(3) non-profit organization, EIN 83-1367310
         </span>
+    </div>
     </div>
     </div>
 

--- a/htmlpartials/footer.js
+++ b/htmlpartials/footer.js
@@ -2,23 +2,23 @@ const htmlblock = `
     <div class="footer">
     <div class="container">
     <div class="row">
-        <p class="col-md-3">
+        <p class="col-sm-3 col-xs-6">
             <a target="_blank" href="mailto:info@planscore.org"><img src="https://planscore.org/images/email-logo.svg"> info@planscore.org</a>
         </p>
-        <p class="col-md-3">
+        <p class="col-sm-3 col-xs-6">
             <a target="_blank" href="https://twitter.com/PlanScore"><img src="https://planscore.org/images/twitter-logo.svg"> @PlanScore</a>
         </p>
-        <p class="col-md-3">
+        <p class="col-sm-3 col-xs-6">
             <a target="_blank" href="https://github.com/PlanScore/PlanScore"><img src="https://planscore.org/images/github-logo.svg"> Github</a>
         </p>
-        <form class="col-md-3" action="https://www.paypal.com/donate" method="post" target="_top">
+        <form class="col-sm-3 col-xs-6" action="https://www.paypal.com/donate" method="post" target="_top">
             <input type="hidden" name="hosted_button_id" value="C9G45F294EKEG" />
             <input type="submit" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" class="btn btn-primary" value="Donate" style="margin: 0;">
             <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
         </form>
     </div>
     <div class="row">
-        <span class="col-md-12">
+        <span class="col-sm-12">
             PlanScore is a 501(c)(3) non-profit organization, EIN 83-1367310
         </span>
     </div>

--- a/htmlpartials/footer.js
+++ b/htmlpartials/footer.js
@@ -13,7 +13,7 @@ const htmlblock = `
         </p>
         <form class="col-md-3" action="https://www.paypal.com/donate" method="post" target="_top">
             <input type="hidden" name="hosted_button_id" value="C9G45F294EKEG" />
-            <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
+            <input type="submit" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" class="btn btn-primary" value="Donate" style="margin: 0;">
             <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
         </form>
     </div>


### PR DESCRIPTION
it looked a bit off to me before. 

before/after:


![image](https://user-images.githubusercontent.com/39191/123528178-6a338100-d69a-11eb-869e-a6a7eb7fc479.png)



also, here's with some extra outlines so you can see the grid/positioning more obviously. (on mobile the 4 items will stack as 2x2, as well.)
![image](https://user-images.githubusercontent.com/39191/123528209-99e28900-d69a-11eb-9ea8-aa514b1e3cd6.png)



I also replaced the Paypal image button with the site's current primary button styles.  I'm fine reverting this bit, but wanted to propose it.

@spncr this work for you?