### PR TITLE
bellcharts: background-image to foreground img

### DIFF
--- a/_common/constants.js
+++ b/_common/constants.js
@@ -209,8 +209,24 @@ export const BELLCURVE_SPREAD = {
     },
 };
 
+// The metricid's passed to drawBiasBellChart don't match the images/*_curve.svg filename pattern exactly.
+export const BELLCURVE_METRIC_TO_FILENAME_SLUG = {
+    'mm': 'mmd',
+    'pb': 'bias',
+    'eg': 'eg',
+};
+
 // Efficiency Gap wasted vote chart; colors
 export const WASTEDVOTE_CHART_WASTED_D = '#0049A8';
 export const WASTEDVOTE_CHART_WASTED_R = '#C71C36';
 export const WASTEDVOTE_CHART_USEFUL_D = '#99b7dc';
 export const WASTEDVOTE_CHART_USEFUL_R = '#e8a4ad';
+
+// What host the sitewite assets are being pulled from
+let current_origin;
+try {
+    current_origin = new URL(document.currentScript.src).origin
+} catch (e) {
+    current_origin = 'https://planscore.org'
+}
+export const STATIC_CONTENT_ORIGIN = current_origin;

--- a/_common/functions.js
+++ b/_common/functions.js
@@ -2,9 +2,7 @@
 // SHARED UTILITY FUNCTIONS
 //
 
-import { BIAS_BALANCED_THRESHOLD } from './constants';
-import { COLOR_GRADIENT } from './constants';
-import { BELLCURVE_SPREAD } from './constants';
+import { BIAS_BALANCED_THRESHOLD, COLOR_GRADIENT, BELLCURVE_SPREAD, BELLCURVE_METRIC_TO_FILENAME_SLUG, STATIC_CONTENT_ORIGIN } from './constants';
 
 
 /*
@@ -49,15 +47,17 @@ export const lookupBias = (whichmetric, score, boundtype) => {
     };
 };
 
-// the bell charts are a bit of a trick: a DIV with CSS to give an image background, then DIVs for the marker line and labels
-// the div.metric-bellchart has additional CSS classes, to use a colorful background-image which looks like a bell curve
+// the bell charts are a bit of a trick. An IMG that's stretched, then DIVs for the marker line and labels
 // see also bellcurves.scss
-export const drawBiasBellChart = (whichone, datavalue, htmldivid, boundtype, planorelection) => {
-    // replace CSS classes to change which curve image is being displayed as the backdrop
+export const drawBiasBellChart = (metricid, datavalue, htmldivid, boundtype, planorelection) => {
     const $div = $(`#${htmldivid}`);
-    $div.removeClass('pb').removeClass('eg').removeClass('mm').addClass(whichone);
-    $div.removeClass('ushouse').removeClass('statehouse').removeClass('statesenate').addClass(boundtype);
-    $div.removeClass('election').removeClass('plan').addClass(planorelection);
+    // Set the img src according to the combo of metricid + plan/election + office.
+    $div.find('img.curve').remove();
+    const curveimg = document.createElement('img');
+    curveimg.className = 'curveimg';
+    console.assert(BELLCURVE_METRIC_TO_FILENAME_SLUG[metricid]);
+    curveimg.src = `${STATIC_CONTENT_ORIGIN}/images/${boundtype}_${BELLCURVE_METRIC_TO_FILENAME_SLUG[metricid]}_${planorelection}_curve.svg`;
+    $div.find('div.curve').prepend(curveimg);
 
     // normalize the value into a range of 0% to 100% within that range, to form an X axis position
     // 0% is the furthest left; 100% furthest right; 50% balanced
@@ -66,10 +66,10 @@ export const drawBiasBellChart = (whichone, datavalue, htmldivid, boundtype, pla
     // so SUBTRACT the bias to shift a positive/democrat bias toward blue left
     const $markline  = $div.find('div.markline');
     const $marklabel = $div.find('div.marklabel');
-    const spread = BELLCURVE_SPREAD[boundtype][whichone];
+    const spread = BELLCURVE_SPREAD[boundtype][metricid];
     let percentile = 0.5 - (0.5 * datavalue / spread);
     percentile = Math.min(Math.max(percentile, 0), 1);
-    // console.log([ `drawBiasBellChart() ${whichone}`, spread, datavalue, percentile ]);
+    // console.log([ `drawBiasBellChart() ${metricid}`, spread, datavalue, percentile ]);
 
     $markline.css({ 'left':`${100 * percentile}%` });
     $marklabel.css({ 'left':`${100 * percentile}%` });

--- a/_common/styles/bellcurves.scss
+++ b/_common/styles/bellcurves.scss
@@ -1,7 +1,7 @@
 /*
  * BELLCHART DIAGRAMS
  * bellcharts indicating the plan's percentile rating
- * a bit of a visual trick: a single-bar column chart, and a stretching background of a bell curve for visual reference
+ * a bit of a visual trick: a single-bar column chart, and a stretching bell curve image for visual reference
  */
 div.metric-bellchart {
     width: 300px;
@@ -23,12 +23,14 @@ div.metric-bellchart {
         width: 100%; /* of the width defined above */
         height: 150px;
         margin: 15px auto 0;
-        background-image: none;  /* overridden in subclasses */
-        background-repeat: no-repeat;
-        background-size: 100% 100%;  /* stretch the graphic to fill the area 100% */
-        background-position: 0 0;
 
         position: relative; /* for positioning the markline */
+
+        .curveimg {
+            width: 100%;
+            height: 100%;
+        }
+
         div.markline {
             position: absolute;
             left: 50%; /* override this to position the markerline at the appropriate % with 0% being far left and 100% being far right */
@@ -103,59 +105,3 @@ li.col-md-4 div.metric-bellchart {
         }
     }
 }
-
-div.metric-bellchart.ushouse.plan.eg div.curve {
-    background-image: url(/images/ushouse_eg_plan_curve.svg);
-}
-div.metric-bellchart.ushouse.plan.mm div.curve {
-    background-image: url(/images/ushouse_mmd_plan_curve.svg);
-}
-div.metric-bellchart.ushouse.plan.pb div.curve {
-    background-image: url(/images/ushouse_bias_plan_curve.svg);
-}
-div.metric-bellchart.statehouse.plan.eg div.curve {
-    background-image: url(/images/statehouse_eg_plan_curve.svg);
-}
-div.metric-bellchart.statehouse.plan.mm div.curve {
-    background-image: url(/images/statehouse_mmd_plan_curve.svg);
-}
-div.metric-bellchart.statehouse.plan.pb div.curve {
-    background-image: url(/images/statehouse_bias_plan_curve.svg);
-}
-div.metric-bellchart.statesenate.plan.eg div.curve {
-    background-image: url(/images/statesenate_eg_plan_curve.svg);
-}
-div.metric-bellchart.statesenate.plan.mm div.curve {
-    background-image: url(/images/statesenate_mmd_plan_curve.svg);
-}
-div.metric-bellchart.statesenate.plan.pb div.curve {
-    background-image: url(/images/statesenate_bias_plan_curve.svg);
-}
-div.metric-bellchart.ushouse.election.eg div.curve {
-    background-image: url(/images/ushouse_eg_election_curve.svg);
-}
-div.metric-bellchart.ushouse.election.mm div.curve {
-    background-image: url(/images/ushouse_mmd_election_curve.svg);
-}
-div.metric-bellchart.ushouse.election.pb div.curve {
-    background-image: url(/images/ushouse_bias_election_curve.svg);
-}
-div.metric-bellchart.statehouse.election.eg div.curve {
-    background-image: url(/images/statehouse_eg_election_curve.svg);
-}
-div.metric-bellchart.statehouse.election.mm div.curve {
-    background-image: url(/images/statehouse_mmd_election_curve.svg);
-}
-div.metric-bellchart.statehouse.election.pb div.curve {
-    background-image: url(/images/statehouse_bias_election_curve.svg);
-}
-div.metric-bellchart.statesenate.election.eg div.curve {
-    background-image: url(/images/statesenate_eg_election_curve.svg);
-}
-div.metric-bellchart.statesenate.election.mm div.curve {
-    background-image: url(/images/statesenate_mmd_election_curve.svg);
-}
-div.metric-bellchart.statesenate.election.pb div.curve {
-    background-image: url(/images/statesenate_bias_election_curve.svg);
-}
-


### PR DESCRIPTION
The primary motivation of this change is printing compatibility (#4). 🖨️ 
The bellcurves for the 3 metrics go from being stretched background images to stretched _foreground_ images. :)  

I confirmed this change works as expected when sitewide.{js css} are pulled into the scoring side, as well.


Aside from printing, this change shouldn't have any user-visible effect.