### PR TITLE
Bellchart population control

### DIFF
--- a/_common/functions.js
+++ b/_common/functions.js
@@ -52,7 +52,7 @@ export const lookupBias = (whichmetric, score, boundtype) => {
 export const drawBiasBellChart = (metricid, datavalue, htmldivid, boundtype, planorelection) => {
     const $div = $(`#${htmldivid}`);
     // Set the img src according to the combo of metricid + plan/election + office.
-    $div.find('img.curve').remove();
+    $div.find('img.curveimg').remove();
     const curveimg = document.createElement('img');
     curveimg.className = 'curveimg';
     console.assert(BELLCURVE_METRIC_TO_FILENAME_SLUG[metricid]);


### PR DESCRIPTION
@paulirish  @migurski 
Right now, on `development` there is a bug where changing the plan year adds a new bellcurve image and they multiply indefinitely as new images.

I think I found a fix, but wanted you to approve it before I merge, in case I broke something else or misunderstood the bug.

Try clicking around to a few different plan years on this page to see the bell charts multiply:
https://dev.planscore.org/texas/#!1988-plan-ushouse-eg

Thanks!