### PR TITLE
print css: improve the appearance when printing

### DIFF
--- a/_common/styles/bellcurves.scss
+++ b/_common/styles/bellcurves.scss
@@ -50,6 +50,10 @@ div.metric-bellchart {
             @media screen and (max-width: $screen-xxs) {
                 top: 30px;
             }
+            /* Override bootstrap print styles. https://github.com/PlanScore/FrontPage/issues/4v */
+            @media print {
+                background-color: black !important;
+            }
         }
 
         div.marklabel {
@@ -75,6 +79,11 @@ div.metric-bellchart {
             }  
             @media screen and (max-width: $screen-xxs) {
                 top: 15px;
+            }
+            /* Override bootstrap print styles. https://github.com/PlanScore/FrontPage/issues/4v */
+            @media print {
+                background-color: black !important;
+                color: white !important;
             }
         }
         div.marklabel.right {

--- a/_common/styles/general.scss
+++ b/_common/styles/general.scss
@@ -310,3 +310,15 @@ div.right-text {
 .highcharts-title {
     font-family: 'Roboto', sans-serif !important;
 }
+
+
+/* revert many of bootstrap v3 print styles. https://github.com/PlanScore/FrontPage/issues/4
+   TODO: upgrade to bootstrap 4+, which doesnt have these. */
+@media print {
+  a[href]:after {
+      content: none;
+  }
+  .navbar {
+    display: block;
+  }
+}


### PR DESCRIPTION
as mentioned in #4, bootstrap v3 does a bunch of printstyle stuff that's ultimately pretty annoying and IMO makes the UX worse.

The changes in this PR:
* link hrefs were being inlined (eg `We have data about 5 plans, covering 25 elections.(/about/historical-data/).`  I took that out
* clc logo in the footer was getting huge. 
* topnav and logo were being hidden. i brought 'em back
* the bellcurve marker was being hidden, but i'm forcing them back (they don't show without background-graphics checked, but the white line of absence is partially useful


update (jul 31): the footer logo adjustment was moved to #20 

some before/after:
![image](https://user-images.githubusercontent.com/39191/124998862-faaa8380-e001-11eb-8e65-ab54426789ed.png)
![image](https://user-images.githubusercontent.com/39191/124999327-b370c280-e002-11eb-8179-affe7d42dd3a.png)
