### PR TITLE
reduce css duplication

### DIFF
--- a/_statetemplate/state_template.scss
+++ b/_statetemplate/state_template.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/alabama/index.scss
+++ b/alabama/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/alaska/index.scss
+++ b/alaska/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/arizona/index.scss
+++ b/arizona/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/arkansas/index.scss
+++ b/arkansas/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/california/index.scss
+++ b/california/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/colorado/index.scss
+++ b/colorado/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/connecticut/index.scss
+++ b/connecticut/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/delaware/index.scss
+++ b/delaware/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/florida/index.scss
+++ b/florida/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/georgia/index.scss
+++ b/georgia/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/hawaii/index.scss
+++ b/hawaii/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/idaho/index.scss
+++ b/idaho/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/illinois/index.scss
+++ b/illinois/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/index.scss
+++ b/index.scss
@@ -1,6 +1,4 @@
 @import 'sitewide';
-@import '_common/styles/boundarypicker';
-@import '_common/styles/tabbedcontent';
 
 .title,
 .subtitle,

--- a/indiana/index.scss
+++ b/indiana/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/iowa/index.scss
+++ b/iowa/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/kansas/index.scss
+++ b/kansas/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/kentucky/index.scss
+++ b/kentucky/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/louisiana/index.scss
+++ b/louisiana/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/maine/index.scss
+++ b/maine/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/maryland/index.scss
+++ b/maryland/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/massachusetts/index.scss
+++ b/massachusetts/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/michigan/index.scss
+++ b/michigan/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/minnesota/index.scss
+++ b/minnesota/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/mississippi/index.scss
+++ b/mississippi/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/missouri/index.scss
+++ b/missouri/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/montana/index.scss
+++ b/montana/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/nebraska/index.scss
+++ b/nebraska/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/nevada/index.scss
+++ b/nevada/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/new_hampshire/index.scss
+++ b/new_hampshire/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/new_jersey/index.scss
+++ b/new_jersey/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/new_mexico/index.scss
+++ b/new_mexico/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/new_york/index.scss
+++ b/new_york/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/north_carolina/index.scss
+++ b/north_carolina/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/north_dakota/index.scss
+++ b/north_dakota/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/ohio/index.scss
+++ b/ohio/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/oklahoma/index.scss
+++ b/oklahoma/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/oregon/index.scss
+++ b/oregon/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/pennsylvania/index.scss
+++ b/pennsylvania/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/rhode_island/index.scss
+++ b/rhode_island/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/south_carolina/index.scss
+++ b/south_carolina/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/south_dakota/index.scss
+++ b/south_dakota/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/tennessee/index.scss
+++ b/tennessee/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/texas/index.scss
+++ b/texas/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/utah/index.scss
+++ b/utah/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/vermont/index.scss
+++ b/vermont/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/virginia/index.scss
+++ b/virginia/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/washington/index.scss
+++ b/washington/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/west_virginia/index.scss
+++ b/west_virginia/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/wisconsin/index.scss
+++ b/wisconsin/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {

--- a/wyoming/index.scss
+++ b/wyoming/index.scss
@@ -1,8 +1,5 @@
 @import 'sitewide';
-@import '_common/styles/bellcurves';
-@import '_common/styles/boundarypicker';
 @import '_common/styles/seatshare';
-@import '_common/styles/tabbedcontent';
 @import '_common/styles/wastedvotes';
 
 h2:first-child {


### PR DESCRIPTION
This is a followup to [Expanded sitewide.scss to better support scoring site · PlanScore/FrontPage@fdb550d](https://github.com/PlanScore/FrontPage/commit/fdb550db11eeb2521e2226c2a6a7ff18558db7a5)

The two changes here are to `/index.scss` and `_statetemplate/state_template.scss`. The other 50 are thx to running `yarn states`.

The duplication isn't causing any real harm, but its just extra bytes.

You can verify by inspecting the "Partisan Bias" tab on dev.planscore and you'll spot the double styles:
![image](https://user-images.githubusercontent.com/39191/125000798-05671780-e006-11eb-9fea-9d65e72e9e3e.png)

and same thing on a state page.

