### PR TITLE
drop h1 font-size to avoid textwrap on homepage

### DIFF
--- a/_common/styles/general.scss
+++ b/_common/styles/general.scss
@@ -22,7 +22,7 @@ h1, h2, h3 {
 }
 
 h1 {
-  font-size: 60px;
+  font-size: 54px;
   line-height: 70px;
   color: $navy;
 


### PR DESCRIPTION
since the recent text adjustments for the homepage headings, we're now SO very close to avoiding this text wrapping.  

before / after

![image](https://user-images.githubusercontent.com/39191/127791186-4bf916e7-0d4f-4f6d-a323-2f4412928507.png)
