### PR TITLE
remove unneeded highcharts data module

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -7,7 +7,6 @@
 
   <!-- Highcharts does charts and also maps -->
   <script src="https://code.highcharts.com/maps/8.0.4/highmaps.js"></script>
-  <script src="https://code.highcharts.com/maps/modules/data.js"></script>
   <script src="/data/usmapchart.json"></script>
 
   <!-- PapaParse CSV reader -->


### PR DESCRIPTION
fixes https://github.com/PlanScore/PlanScore/issues/405 - the `Cannot read property 'doc' of undefined` error

afaict, this module isn't needed. I blocked the request and the map on the homepage works just fine.  

I tracked back to where it was added... and I also don't see any [csv/table/googlespreadsheets references](https://www.highcharts.com/docs/working-with-data/data-module) there, so i'm not sure why it was ever added: https://github.com/PlanScore/FrontPage/commit/e3ca9343dbd2395ed274b65ff707b7b8cc601a24#diff-b769209f263118a83776e8b4e6610d58bc16f35ec8de0062e6d5c20352b3ea74R16




