### PR TITLE
z-index fix for plan page

### DIFF
--- a/_common/styles/general.scss
+++ b/_common/styles/general.scss
@@ -138,7 +138,7 @@ nav .mobile-only {
 
 .announcement {
   position: fixed;
-  z-index: 1001;
+  z-index: 1002;
   top: 0;
 
   width: 100%;


### PR DESCRIPTION
It looks like `z-index: 1001` is already being used by some elements on the plan page (ie: https://github.com/PlanScore/PlanScore/blob/8eea60a50b050c829acf185f75822fe9e0a32f24/planscore/website/static/plan.css#L102 )

This means that this table header overlaps the announcement, currently only on mobile.

You could either re-adjust z-indexes in the `PlanScore` repo, or push the announcement further up the stack (which this PR would do)