### PR TITLE
Add map navigation to library

### DIFF
--- a/library/index.js6
+++ b/library/index.js6
@@ -22,6 +22,7 @@ const MAP_NODATA_VALUE = 999999;
 const MAP_NODATA_FILLCOLOR = '#ffffff';
 const MAP_NODATA_LABELCOLOR = '#cccccc';
 const MAP_BORDER_COLOR = '#6E6E6E';
+const MAP_PLANS_FILLCOLOR = '#DFDFDF';
 
 // the color of the state labels on the map
 const MAP_LABELSIZE = '9px';
@@ -34,27 +35,78 @@ const MAP_MOUSEOVER_WIDTH = 2;
 // the Esc key
 const KEYCODE_ESC = 27;
 
+// Library pages
+const LIBRARY_STATES = [
+    {abbr: 'AL', name: 'Alabama', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'AK', name: 'Alaska', plans: true, href: '/library/alaska', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'AZ', name: 'Arizona', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'AR', name: 'Arkansas', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'CA', name: 'California', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'CO', name: 'Colorado', plans: true, href: '/library/colorado', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'CT', name: 'Connecticut', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'DE', name: 'Delaware', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'FL', name: 'Florida', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'GA', name: 'Georgia', plans: true, href: '/library/georgia', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'HI', name: 'Hawaii', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'ID', name: 'Idaho', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'IL', name: 'Illinois', plans: true, href: '/library/illinois', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'IN', name: 'Indiana', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'IA', name: 'Iowa', plans: true, href: '/library/iowa', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'KS', name: 'Kansas', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'KY', name: 'Kentucky', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'LA', name: 'Louisiana', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'ME', name: 'Maine', plans: true, href: '/library/maine', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'MD', name: 'Maryland', plans: true, href: '/library/maryland', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'MA', name: 'Massachusetts', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'MI', name: 'Michigan', plans: true, href: '/library/michigan', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'MN', name: 'Minnesota', plans: true, href: '/library/minnesota', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'MS', name: 'Mississippi', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'MO', name: 'Missouri', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'MT', name: 'Montana', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'NE', name: 'Nebraska', plans: true, href: '/library/nebraska', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'NV', name: 'Nevada', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'NH', name: 'New Hampshire', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'NJ', name: 'New Jersey', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'NM', name: 'New Mexico', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'NY', name: 'New York', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'NC', name: 'North Carolina', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'ND', name: 'North Dakota', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'OH', name: 'Ohio', plans: true, href: '/library/ohio', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'OK', name: 'Oklahoma', plans: true, href: '/library/oklahoma', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'OR', name: 'Oregon', plans: true, href: '/library/oregon', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'PA', name: 'Pennsylvania', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'RI', name: 'Rhode Island', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'SC', name: 'South Carolina', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'SD', name: 'South Dakota', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'TN', name: 'Tennessee', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'TX', name: 'Texas', plans: true, href: '/library/texas', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'UT', name: 'Utah', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'VT', name: 'Vermont', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'VA', name: 'Virginia', plans: true, href: '/library/virginia', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'WA', name: 'Washington', plans: true, href: '/library/washington', color: MAP_PLANS_FILLCOLOR},
+    {abbr: 'WV', name: 'West Virginia', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'WI', name: 'Wisconsin', plans: false, href: '/library/no_plans', color: MAP_NODATA_FILLCOLOR},
+    {abbr: 'WY', name: 'Wyoming', plans: true, href: '/library/wyoming', color: MAP_PLANS_FILLCOLOR},
+];
+
 $(document).ready(function () {
   initStatePicker();
   renderMap();
 })
 
 window.initStatePicker = () => {
-  for (const [stateabbr, statename] of Object.entries(STATE_CODE_TO_NAME)) {
-    const link_name = statename.toLowerCase().replace(/ /g,"_");
-
+  for (const state of LIBRARY_STATES) {
     $('#state-library-list').append(
       $("<li>").append($("<a>")
-        .text(statename)
-        .attr('href','/library/' + link_name)
+        .text(state.name)
+        .attr('href', state.href)
         .attr('class', 'state-link')
-        .click(goToStateLibraryIfExists)
       )
     );
 
     $('#states-list').append(
       $("<option>")
-        .text(statename)
+        .text(state.name)
     );
   }
 
@@ -102,19 +154,17 @@ window.renderMap = () => {
         },
         series: [{
             // use the Highcharts-provided US states, joining on their "postal" to our "abbr"
-            data: [
-                {abbr: 'CO', name: 'Colorado'},
-                {abbr: 'MI', name: 'Michigan'},
-            ],
+            data: LIBRARY_STATES,
             mapData: polygons,
             borderColor: MAP_BORDER_COLOR,
+            colorKey: 'color',
             joinBy: ['postal', 'abbr'],
             // labels make small states easier to see, cursor makes it obvious to click
             cursor: 'pointer',
             dataLabels: {
                 enabled: true,
                 formatter: function () {
-                    if (this.point.value == MAP_NODATA_VALUE) {
+                    if (!this.point.plans) {
                         return `<span style="color: ${MAP_NODATA_LABELCOLOR}">${this.point.abbr}</span>`;
                     }
                     else {
@@ -137,21 +187,16 @@ window.renderMap = () => {
             // click events: call the popup maker
             events: {
                 click: function (e) {
-                    console.log('Clicked', e.point);
-
-                    const link_name = e.point.name.toLowerCase().replace(/ /g,"_");
-                    const moreinfourl = `/library/${link_name}/`;
-
                     /*
-                    // in any case, log the selection before we go
+                    // the selection before we go
                     logToGoogleAnalytics('selectlibrarystate', e.point.name);
                     */
 
                     if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) {
-                        window.open(moreinfourl);
+                        window.open(e.point.href);
                     }
                     else {
-                        document.location.href = moreinfourl;
+                        document.location.href = e.point.href;
                     }
                 }
             },

--- a/library/index.js6
+++ b/library/index.js6
@@ -16,8 +16,27 @@ import { STATE_CODE_TO_NAME } from "/_common/constants";
 // anything goes: jQuery, ES2015, whatever you need
 //
 
+// the map uses a choropleth constructed from BELLCURVE_SPREAD
+// but for nodata states, use this NODATA value and this color fill
+const MAP_NODATA_VALUE = 999999;
+const MAP_NODATA_FILLCOLOR = '#ffffff';
+const MAP_NODATA_LABELCOLOR = '#cccccc';
+const MAP_BORDER_COLOR = '#6E6E6E';
+
+// the color of the state labels on the map
+const MAP_LABELSIZE = '9px';
+const MAP_LABELCOLOR = 'black';
+
+// style for mouseover-ing the states on the map
+const MAP_MOUSEOVER_COLOR = '#333333';
+const MAP_MOUSEOVER_WIDTH = 2;
+
+// the Esc key
+const KEYCODE_ESC = 27;
+
 $(document).ready(function () {
   initStatePicker();
+  renderMap();
 })
 
 window.initStatePicker = () => {
@@ -39,4 +58,103 @@ window.initStatePicker = () => {
     );
   }
 
+};
+
+window.renderMap = () => {
+    console.log('yo');
+
+    // Highcharts trick: load up the us-small data (see the SCRIPT tag for usmapchart.json)
+    // which includes breakout boxes for the small New England States (https://github.com/PlanScore/PlanScore/issues/78)
+    // preprocess it to add the state's ABBR as the label for the boxes
+    const polygons = Highcharts.geojson(Highcharts.maps['countries/us/custom/us-small']);
+    const has_callout_boxes = [ 'NJ', 'MD', 'DE', 'CT', 'RI', 'MA', 'NH', 'VT' ];
+    $.each(polygons, function () {
+        var path = this.path, copy = { path: path };
+
+        if (has_callout_boxes.indexOf(this.properties.postal) !== -1) {
+            Highcharts.seriesTypes.map.prototype.getBox.call({}, [copy]);
+            this.middleX = ((path[1] + path[4]) / 2 - copy._minX) / (copy._maxX - copy._minX); // eslint-disable-line no-underscore-dangle
+            this.middleY = ((path[2] + path[7]) / 2 - copy._minY) / (copy._maxY - copy._minY); // eslint-disable-line no-underscore-dangle
+        }
+    });
+
+    const newmapchart = Highcharts.mapChart('map', {
+        chart: {
+            borderWidth: 0,
+            spacing: [ 0, 0, 0, 0 ],
+        },
+        credits: {
+            enabled: false,
+        },
+        title: {
+            text: '',  // no big title
+        },
+        legend: {
+            enabled: false,  // we have a custom-crafted label
+        },
+        /*
+        colorAxis: {
+            dataClasses: map_choropleth_colors,
+        },
+        */
+        tooltip: {
+            enabled: false,
+        },
+        series: [{
+            // use the Highcharts-provided US states, joining on their "postal" to our "abbr"
+            data: [
+                {abbr: 'CO', name: 'Colorado'},
+                {abbr: 'MI', name: 'Michigan'},
+            ],
+            mapData: polygons,
+            borderColor: MAP_BORDER_COLOR,
+            joinBy: ['postal', 'abbr'],
+            // labels make small states easier to see, cursor makes it obvious to click
+            cursor: 'pointer',
+            dataLabels: {
+                enabled: true,
+                formatter: function () {
+                    if (this.point.value == MAP_NODATA_VALUE) {
+                        return `<span style="color: ${MAP_NODATA_LABELCOLOR}">${this.point.abbr}</span>`;
+                    }
+                    else {
+                        return this.point.abbr;
+                    }
+                },
+                style: {
+                    fontSize: MAP_LABELSIZE,
+                    color: MAP_LABELCOLOR,
+                    textOutline: false
+                }
+            },
+            states: {
+                hover: {
+                    brightness: 0,
+                    borderColor: MAP_MOUSEOVER_COLOR,
+                    borderWidth: MAP_MOUSEOVER_WIDTH,
+                }
+            },
+            // click events: call the popup maker
+            events: {
+                click: function (e) {
+                    console.log('Clicked', e.point);
+
+                    const link_name = e.point.name.toLowerCase().replace(/ /g,"_");
+                    const moreinfourl = `/library/${link_name}/`;
+
+                    /*
+                    // in any case, log the selection before we go
+                    logToGoogleAnalytics('selectlibrarystate', e.point.name);
+                    */
+
+                    if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) {
+                        window.open(moreinfourl);
+                    }
+                    else {
+                        document.location.href = moreinfourl;
+                    }
+                }
+            },
+        }]
+    });
 };

--- a/library/index.scss
+++ b/library/index.scss
@@ -5,6 +5,19 @@
 
 /* use SASS here */
 
+#map {
+  height: 400px;
+  width: 100%;
+
+  @media screen and (max-width: $screen-sm) {
+    max-height: 66vw; /* phone screens, try not to have extra space at top+bottom */
+  }
+
+  path.highcharts-key-us-dc {
+    display: none;  /* https://github.com/PlanScore/PlanScore/issues/78 adds small-states legend, this hides DC which we don't have */
+  }
+}
+
 .states {
 	display: grid;
 

--- a/library/index.src.html
+++ b/library/index.src.html
@@ -5,6 +5,11 @@
 
     <!--[include_head]-->
 
+    <!-- Highcharts does charts and also maps -->
+    <script src="https://code.highcharts.com/maps/8.0.4/highmaps.js"></script>
+    <script src="https://code.highcharts.com/maps/modules/data.js"></script>
+    <script src="/data/usmapchart.json"></script>
+
     <!-- this page's own JS + CSS -->
     <link href="index.css?[hash]" rel="stylesheet" />
     <script src="index.js?[hash]"></script>
@@ -35,6 +40,7 @@
 
     <h2>Explore all redistricting plans by state.</h2>
     <hr>
+    <div id="map"></div>
     <ul class="states" id="state-library-list">
       <!--Populates in js6 initStatePicker();-->
     </ul>


### PR DESCRIPTION
Introduces map navigation element from front page to explore current library states.

Also creates new `LIBRARY_STATES` array in `library/index.js6` to control active pages and chart display. 

<img width="1018" alt="Screen Shot 2021-10-02 at 8 50 50 AM" src="https://user-images.githubusercontent.com/58730/135723651-4f4c4a1c-f926-4c3a-af9c-f7d0b3e51105.png">
